### PR TITLE
Refine hero styling to match reference landing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0f0f0f;
+  --foreground: #f5f5f5;
 }
 
 @theme inline {
@@ -20,18 +20,250 @@
 }
 
 body {
-  background: var(--background);
+  background: linear-gradient(180deg, #1b1b1b 0%, #0f0f0f 100%);
   color: var(--foreground);
   font-family: var(--font-sans);
+  margin: 0;
 }
 
-/* Estilos personalizados para replicar exactamente la landing */
+main {
+  display: block;
+}
+
+.landing-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.landing-container {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 2rem 1.5rem 6rem;
+}
+
+.section-title {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.section-card {
+  background: rgba(28, 28, 28, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+/* Header */
+.top-banner {
+  background: #111111;
+  border-bottom: 3px solid #e50914;
+  color: #f9d649;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 100;
+  text-transform: uppercase;
+}
+
+.top-banner__inner {
+  margin: 0 auto;
+  max-width: 1280px;
+  padding: 0.55rem 1.5rem;
+  text-align: center;
+  color: #f9d649;
+}
+
+.top-banner__highlight {
+  color: #ff2c2c;
+}
+
+/* Logo strip */
+.logo-strip {
+  background: #272727;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.45);
+  padding: 1.5rem 2rem;
+  margin-top: 2rem;
+  color: #ffffff;
+}
+
+.logo-strip__row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.logo-strip__brand {
+  height: 70px;
+  width: auto;
+}
+
+.logo-strip__separator {
+  width: 1px;
+  height: 45px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.logo-strip__caption {
+  margin-top: 1rem;
+  text-align: center;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.user-access-link {
+  margin-top: 1.5rem;
+  text-align: center;
+  padding: 1rem 1.5rem;
+  border-radius: 14px;
+  border: 1px solid rgba(51, 102, 255, 0.35);
+  background: rgba(51, 102, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(51, 102, 255, 0.12);
+}
+
+.user-access-link__anchor {
+  color: #6fa5ff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+}
+
+.user-access-link__anchor:hover {
+  text-decoration: underline;
+}
+
+/* Hero copy */
+.hero-claim {
+  margin: 2.5rem auto 2rem;
+  text-align: center;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.hero-claim strong {
+  color: #ff2c2c;
+}
+
+.hero-claim span {
+  color: #f9d649;
+}
+
+.product-strip {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08) 0%, rgba(0, 0, 0, 0) 100%);
+  padding: 1.5rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  justify-content: center;
+}
+
+.product-strip img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45);
+}
+
+.copy-headline {
+  display: flex;
+  justify-content: center;
+  margin: 3rem 0 2rem;
+}
+
+.badge-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #ffe761 0%, #ffbe0b 50%, #ffe761 100%);
+  color: #111;
+  font-weight: 800;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  box-shadow: inset 0 -4px 10px rgba(0, 0, 0, 0.2);
+}
+
+/* CTA */
+.cta-sticky {
+  position: sticky;
+  bottom: 0;
+  z-index: 120;
+  background: rgba(10, 10, 10, 0.95);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.5rem 1rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.cta-arrow {
+  width: clamp(140px, 22vw, 220px);
+  height: auto;
+}
+
+.cta-deadline {
+  text-align: center;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #ffffff;
+  max-width: 640px;
+}
+
+.cta-deadline span {
+  color: #ff2c2c;
+}
+
+.cta-button {
+  background: linear-gradient(180deg, #ff2c2c 0%, #c70f0f 100%);
+  color: #ffffff;
+  padding: 1.15rem 2.5rem;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  width: min(640px, 100%);
+  box-shadow: 0 18px 45px rgba(199, 15, 15, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta-button:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 25px 55px rgba(199, 15, 15, 0.55);
+}
+
+.cta-subtext {
+  font-size: 0.85rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* Utility */
 .text-red-600 {
-  color: #ff0000;
+  color: #ff2c2c;
 }
 
 .text-yellow-400 {
-  color: #ffff00;
+  color: #f9d649;
 }
 
 .text-blue-600 {
@@ -59,36 +291,20 @@ body {
   font-weight: bold;
 }
 
-/* Estilos para el header sticky */
-.header-sticky {
-  background-color: #ffff00;
-  color: #000000;
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-}
+@media (max-width: 768px) {
+  .logo-strip {
+    padding: 1.5rem;
+  }
 
-/* Estilos para el botón CTA sticky */
-.cta-sticky {
-  position: sticky;
-  bottom: 0;
-  z-index: 40;
-  background-color: #ff0000;
-  padding: 1rem;
-  box-shadow: 0 -4px 6px -1px rgba(0, 0, 0, 0.1);
-}
+  .logo-strip__brand {
+    height: 56px;
+  }
 
-.cta-button {
-  background-color: #ff0000;
-  color: white;
-  padding: 12px 24px;
-  border-radius: 4px;
-  display: inline-block;
-  text-decoration: none;
-  font-weight: bold;
-  text-align: center;
-  width: 100%;
-  max-width: 500px;
-  margin: 0 auto;
+  .hero-claim {
+    font-size: 1.25rem;
+  }
+
+  .cta-subtext {
+    letter-spacing: 0.18em;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,10 +18,10 @@ import Footer from '../components/Footer';
 
 export default function Home() {
   return (
-    <div className="min-h-screen">
+    <div className="landing-page">
       <LandingHeader />
-      
-      <main className="container mx-auto px-4">
+
+      <main className="landing-container">
         <HotmartLogo />
         <UserAccessLink />
         <GuaranteeBanner />
@@ -35,11 +35,10 @@ export default function Home() {
         <BenefitsSection />
         <InstructorInfo />
         <FAQSection />
-        <CTAButton />
         <Footer />
       </main>
+
+      <CTAButton />
     </div>
   );
 }
-
-import Image from "next/image";

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -3,40 +3,23 @@ import React from 'react';
 const CTAButton = () => {
   return (
     <div className="cta-sticky">
-      {/* Imagen de flecha */}
-      <div className="py-4">
-        <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-          <img 
-            loading="lazy" 
-            decoding="async" 
-            src="https://i0.wp.com/blacks.university/wp-content/uploads/2024/10/arrow-brushes-design-png-34.png?fit=252%2C300&amp;ssl=1" 
-            alt="" 
-            className="mx-auto"
-            style={{ width: '252px', height: '300px' }}
-          />
-        </a>
-      </div>
-      
-      {/* Texto de inscripciones */}
-      <div className="py-4">
-        <p style={{ textAlign: 'center' }}><strong>INSCRIPCIONES ABIERTAS HASTA HOY  <span style={{ color: '#ff0000' }}>Dom 28 septiembre</span> a las <span style={{ color: '#ff0000' }}>10:00 PM</span> hora Colombia</strong></p>
-      </div>
-      
-      {/* Botón CTA */}
-      <div className="py-6">
-        <div className="elementor-button-wrapper">
-          <a 
-            className="cta-button"
-            href="https://pay.hotmart.com/G99109427E?checkoutMode=10"
-          >
-            <span className="elementor-button-content-wrapper">
-              <span className="elementor-button-text">
-                CLICK AQUÍ PARA COMENZAR A VENDER NUESTROS PRODUCTOS DIGITALES Y GENERAR INGRESOS INMEDIATAMENTE...
-              </span>
-            </span>
-          </a>
-        </div>
-      </div>
+      <img
+        className="cta-arrow"
+        src="https://i0.wp.com/blacks.university/wp-content/uploads/2024/10/arrow-brushes-design-png-34.png?fit=252%2C300&ssl=1"
+        alt="Flecha hacia el botón de compra"
+        loading="lazy"
+      />
+
+      <p className="cta-deadline">
+        INSCRIPCIONES ABIERTAS HASTA HOY <span>Dom 28 septiembre</span> a las{' '}
+        <span>10:00 PM</span> hora Colombia
+      </p>
+
+      <a className="cta-button" href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
+        CLICK AQUÍ PARA COMENZAR A VENDER NUESTROS PRODUCTOS DIGITALES Y GENERAR INGRESOS INMEDIATAMENTE...
+      </a>
+
+      <span className="cta-subtext">SIN EXPERIENCIA PREVIA</span>
     </div>
   );
 };

--- a/src/components/CopyPasteHeadline.tsx
+++ b/src/components/CopyPasteHeadline.tsx
@@ -4,13 +4,11 @@ import React from 'react';
 
 const CopyPasteHeadline = () => {
   return (
-    <div className="py-6">
-      <h3 className="text-center text-2xl font-bold">
-        <span style={{ backgroundColor: '#ffff00', color: '#000000', padding: '0.5rem 0.5rem', borderRadius: '9999px' }}>
-          ÚNICAMENTE TIENES QUE COPIAR Y PEGAR PARA VENDER Y GANAR HOY MISMO...
-        </span>
-      </h3>
-    </div>
+    <section className="copy-headline">
+      <span className="badge-pill">
+        ÚNICAMENTE TIENES QUE COPIAR Y PEGAR PARA VENDER Y GANAR HOY MISMO...
+      </span>
+    </section>
   );
 };
 

--- a/src/components/GuaranteeBanner.tsx
+++ b/src/components/GuaranteeBanner.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 
 const GuaranteeBanner = () => {
   return (
-    <div className="py-4">
-      <p className="text-center">
-        «Factura mínimo 300 dólares semanales <span style={{ color: '#ff0000' }}>GARANTIZADO</span> comenzando <span style={{ color: '#ffff00' }}>HOY MISMO</span> vendiendo nuestros más de 1.500 Productos Digitales a través de Hotmart®…»
-      </p>
-    </div>
+    <section className="hero-claim">
+      «Factura mínimo 300 dólares semanales <strong>GARANTIZADO</strong> comenzando{' '}
+      <span>HOY MISMO</span> vendiendo nuestros más de 1.500 Productos Digitales a través de Hotmart®…»
+    </section>
   );
 };
 

--- a/src/components/HotmartLogo.tsx
+++ b/src/components/HotmartLogo.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 
 const HotmartLogo = () => {
   return (
-    <div className="text-center py-4">
-      <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-        <img 
-          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/06/hotmartuologos.png?fit=565%2C93&ssl=1" 
-          alt="Hotmart Logo" 
-          className="mx-auto"
-          style={{ width: '565px', height: '93px' }}
+    <section className="logo-strip">
+      <div className="logo-strip__row">
+        <img
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/06/universidad-online-logo.png?resize=260%2C80&ssl=1"
+          alt="Universidad Online"
+          className="logo-strip__brand"
         />
-      </a>
-    </div>
+        <span className="logo-strip__separator" aria-hidden="true" />
+        <img
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/06/hotmart-powered-logo.png?resize=260%2C80&ssl=1"
+          alt="Powered by Hotmart"
+          className="logo-strip__brand"
+        />
+      </div>
+      <p className="logo-strip__caption">
+        USAMOS ACTIVOS VIRTUALES COMO HOTMART, REDES SOCIALES Y LA UNIVERSIDAD ONLINE PARA CREAR INGRESOS 100% DIGITALES.
+      </p>
+    </section>
   );
 };
 

--- a/src/components/LandingHeader.tsx
+++ b/src/components/LandingHeader.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 const LandingHeader = () => {
   return (
-    <div className="header-sticky">
-      <div className="container mx-auto px-4 py-2">
-        <p className="text-center font-bold">
-          <span style={{ color: '#000000' }}>INSCRIPCIONES ABIERTAS HASTA HOY</span> <span style={{ color: '#ff0000' }}>Dom 28 septiembre</span> a las <span style={{ color: '#ff0000' }}>10:00 PM</span> hora Colombia
-        </p>
+    <header className="top-banner">
+      <div className="top-banner__inner">
+        INSCRIPCIONES ABIERTAS HASTA HOY{' '}
+        <span className="top-banner__highlight">Dom 28 septiembre</span> a las{' '}
+        <span className="top-banner__highlight">10:00 PM</span> hora Colombia
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 const ProductImage = () => {
   return (
-    <div className="py-4">
+    <section className="product-strip">
       <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-        <img 
-          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/04/pdhtm.jpg?fit=1425%2C287&ssl=1" 
-          alt="Producto" 
-          className="mx-auto"
-          style={{ width: '800px', height: '161px' }}
+        <img
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/04/pdhtm.jpg?fit=1425%2C287&ssl=1"
+          alt="Colección de productos digitales"
+          loading="lazy"
         />
       </a>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/UserAccessLink.tsx
+++ b/src/components/UserAccessLink.tsx
@@ -2,22 +2,16 @@ import React from 'react';
 
 const UserAccessLink = () => {
   return (
-    <div className="py-2">
-      <p className="text-center">
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#3366ff' }}>
-            <a 
-              style={{ color: '#3366ff', textDecoration: 'underline' }} 
-              href="https://hotmart.com/es/club/blacks-mentorias/products/5332557" 
-              target="_blank" 
-              rel="noopener"
-            >
-              USUARIOS ACTIVOS CLICK AQUI PARA ACCEDER A LA PLATAFORMA
-            </a>
-          </span>
-        </span>
-      </p>
-    </div>
+    <section className="user-access-link">
+      <a
+        className="user-access-link__anchor"
+        href="https://hotmart.com/es/club/blacks-mentorias/products/5332557"
+        target="_blank"
+        rel="noopener"
+      >
+        USUARIOS ACTIVOS CLICK AQUÍ PARA ACCEDER A LA PLATAFORMA
+      </a>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- redesign the top hero styles to match the reference landing with a sticky banner and compact CTA
- create polished sections for the brand logos, hero copy, product strip, and returning user access link
- update the main layout to wrap content in the new styling framework while keeping the CTA anchored at the bottom

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc505cba24832d9c83176167a7ca2d