### PR TITLE
Align landing layout with reference design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,94 +1,504 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-fira-sans), sans-serif;
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --background: #000000;
+  --foreground: #f5f5f5;
 }
 
 body {
-  background: var(--background);
+  margin: 0;
+  background-color: var(--background);
   color: var(--foreground);
-  font-family: var(--font-sans);
+  font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  line-height: 1.5;
 }
 
-/* Estilos personalizados para replicar exactamente la landing */
-.text-red-600 {
-  color: #ff0000;
+a {
+  color: inherit;
 }
 
-.text-yellow-400 {
-  color: #ffff00;
+main {
+  display: block;
 }
 
-.text-blue-600 {
-  color: #3366ff;
+.landing-page {
+  min-height: 100vh;
+  background-color: #000000;
+  display: flex;
+  flex-direction: column;
 }
 
-.text-teal-500 {
-  color: #33cccc;
+.landing-container {
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  padding: 0 1.25rem 4.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
 }
 
-.bg-yellow-400 {
-  background-color: #ffff00;
-  color: #000000;
+.top-banner {
+  background-color: #ffe200;
+  color: #111111;
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.45);
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
 
-.underline {
+.top-banner__inner {
+  margin: 0 auto;
+  max-width: 1280px;
+}
+
+.top-banner__highlight {
+  color: #c40000;
+}
+
+.logo-strip {
+  background: #101010;
+  border: 2px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.75rem 1.25rem;
+  text-align: center;
+}
+
+.logo-strip__row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+}
+
+.logo-strip__brand {
+  max-height: 70px;
+  width: auto;
+}
+
+.logo-strip__caption {
+  margin-top: 1.25rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero-claim {
+  text-align: center;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  text-transform: uppercase;
+  font-weight: 800;
+  line-height: 1.35;
+  margin: 0 auto;
+  max-width: 960px;
+}
+
+.hero-claim strong {
+  color: #ff1b1b;
+}
+
+.hero-claim span {
+  color: #ffe761;
+}
+
+.product-strip {
+  text-align: center;
+}
+
+.product-strip img {
+  width: min(100%, 980px);
+  border: 3px solid #ffe761;
+  border-radius: 10px;
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.45);
+}
+
+.copy-headline {
+  text-align: center;
+}
+
+.copy-headline__badge {
+  display: inline-block;
+  border: 3px solid #ff1b1b;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  background: rgba(255, 0, 0, 0.08);
+}
+
+.user-access-link {
+  text-align: center;
+  padding: 1rem 1.5rem;
+  border: 2px solid rgba(51, 102, 255, 0.75);
+  border-radius: 12px;
+  background: rgba(51, 102, 255, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(51, 102, 255, 0.3);
+}
+
+.user-access-link__anchor {
+  color: #6fa5ff;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+}
+
+.user-access-link__anchor:hover {
   text-decoration: underline;
 }
 
-.text-center {
+.cta-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.cta-section__arrow {
+  width: clamp(140px, 20vw, 210px);
+  height: auto;
+  filter: drop-shadow(0 8px 14px rgba(0, 0, 0, 0.6));
+}
+
+.cta-section__link {
+  display: block;
+  width: min(960px, 100%);
+  background: linear-gradient(180deg, #ff1b1b 0%, #c40000 100%);
+  color: #ffffff;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1.1rem 1.5rem;
+  border-radius: 6px;
   text-align: center;
-}
-
-.font-bold {
-  font-weight: bold;
-}
-
-/* Estilos para el header sticky */
-.header-sticky {
-  background-color: #ffff00;
-  color: #000000;
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-}
-
-/* Estilos para el botón CTA sticky */
-.cta-sticky {
-  position: sticky;
-  bottom: 0;
-  z-index: 40;
-  background-color: #ff0000;
-  padding: 1rem;
-  box-shadow: 0 -4px 6px -1px rgba(0, 0, 0, 0.1);
-}
-
-.cta-button {
-  background-color: #ff0000;
-  color: white;
-  padding: 12px 24px;
-  border-radius: 4px;
-  display: inline-block;
   text-decoration: none;
-  font-weight: bold;
+  box-shadow: 0 10px 0 #720000;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.cta-section__link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 0 #720000;
+}
+
+.section-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
   text-align: center;
   width: 100%;
-  max-width: 500px;
-  margin: 0 auto;
+}
+
+.section-block--panel {
+  background: #101010;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 2.25rem 1.5rem;
+}
+
+.section-block__heading {
+  font-size: 1.45rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.section-block__subtext {
+  color: rgba(255, 255, 255, 0.88);
+  max-width: 920px;
+}
+
+.media-frame {
+  width: min(960px, 100%);
+  border: 4px solid #ffe761;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.55);
+}
+
+.media-frame iframe {
+  display: block;
+  width: 100%;
+  height: clamp(240px, 50vw, 420px);
+}
+
+.stat-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 1.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.stat-links a {
+  color: #33cccc;
+  text-decoration: underline;
+}
+
+.video-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.25rem;
+}
+
+.video-grid iframe {
+  width: 100%;
+  height: 180px;
+  border-radius: 10px;
+  border: 3px solid #2a2a2a;
+  background: #000000;
+}
+
+.transform-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.transform-links a {
+  color: #6fa5ff;
+  text-decoration: underline;
+}
+
+.link-accent {
+  color: #6fa5ff;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  text-decoration: underline;
+}
+
+.link-inline {
+  color: #33cccc;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.mentors-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  width: 100%;
+}
+
+.mentors-banner__heading {
+  font-size: 1.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.mentor-cards {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.mentor-card {
+  background: #101010;
+  border: 1px solid #2a2a2a;
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem;
+  width: min(220px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.mentor-card__photo {
+  width: 110px;
+  height: 110px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #ffe761;
+}
+
+.mentor-card h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.mentor-card p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.benefits-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.benefits-layout ul {
+  padding-left: 1.25rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.benefits-layout ul ul {
+  margin-top: 0.85rem;
+  padding-left: 1.25rem;
+}
+
+.benefits-layout li {
+  line-height: 1.45;
+}
+
+.benefits-layout ul ul li {
+  margin: 0.35rem 0;
+  list-style: disc;
+}
+
+.benefits-highlight {
+  color: #ffe761;
+  font-weight: 700;
+}
+
+.bio-section {
+  background: #101010;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+
+.bio-section p {
+  margin: 0;
+}
+
+.bio-section h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.bio-section ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.bio-section a {
+  color: #33cccc;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.team-photo {
+  width: min(900px, 100%);
+  border-radius: 12px;
+  border: 3px solid #ffe761;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.55);
+}
+
+.footer-block {
+  background: #101010;
+  border-top: 1px solid #2a2a2a;
+  padding: 3rem 1.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.footer-block img {
+  width: min(820px, 100%);
+  height: auto;
+}
+
+.contact-highlight {
+  color: #ffe761;
+  font-weight: 700;
+}
+
+.faq-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.faq-item {
+  background: #0f0f0f;
+  border: 1px solid #2a2a2a;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.faq-question {
+  width: 100%;
+  background: #161616;
+  color: #ffffff;
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 1rem 1.25rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: none;
+  cursor: pointer;
+}
+
+.faq-question:focus {
+  outline: 2px solid #ffe761;
+  outline-offset: 2px;
+}
+
+.faq-answer {
+  padding: 1.25rem;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.55;
+}
+
+@media (max-width: 768px) {
+  .logo-strip__brand {
+    max-height: 56px;
+  }
+
+  .hero-claim {
+    font-size: 1.2rem;
+  }
+
+  .cta-section__link {
+    font-size: 0.95rem;
+    padding: 1rem 0.85rem;
+  }
+
+  .media-frame iframe {
+    height: clamp(220px, 56vw, 320px);
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,22 +18,29 @@ import Footer from '../components/Footer';
 
 export default function Home() {
   return (
-    <div className="min-h-screen">
+    <div className="landing-page">
       <LandingHeader />
-      
-      <main className="container mx-auto px-4">
+
+      <main className="landing-container">
         <HotmartLogo />
         <UserAccessLink />
         <GuaranteeBanner />
         <ProductImage />
         <CopyPasteHeadline />
+        <CTAButton />
         <PromoVideo />
+        <CTAButton />
         <SalesTestimonials />
         <SalesStats />
+        <CTAButton />
         <VideoGallery />
+        <CTAButton />
         <UserTransformations />
+        <CTAButton />
         <BenefitsSection />
+        <CTAButton />
         <InstructorInfo />
+        <CTAButton />
         <FAQSection />
         <CTAButton />
         <Footer />
@@ -41,5 +48,3 @@ export default function Home() {
     </div>
   );
 }
-
-import Image from "next/image";

--- a/src/components/BenefitsSection.tsx
+++ b/src/components/BenefitsSection.tsx
@@ -2,56 +2,84 @@ import React from 'react';
 
 const BenefitsSection = () => {
   return (
-    <div className="py-8">
-      <h1 style={{ textAlign: 'center' }}>Activa una cuenta en Blacks.University® recibe los siguientes beneficios:</h1>
-      <ul>
-        <li>Acceso <span style={{ color: '#ffff00' }}>para toda la vida</span> a las mentorías en vivo todos los días de lunes a viernes de 9:00 AM a 12:00 M Hora Colombia.
-          <ul>
-            <li>
-              <span style={{ textDecoration: 'underline' }}>
-                <span style={{ color: '#3366ff' }}>
-                  <a style={{ color: '#3366ff' }} href="https://blacks.university/wp-content/uploads/2025/04/lunes.jpg">
-                    <span style={{ color: '#33cccc', textDecoration: 'underline' }}>Tráfico Pago</span>
-                  </a>
-                </span>
-              </span> –{" "}
-              <span style={{ textDecoration: 'underline' }}>
-                <span style={{ color: '#33cccc' }}>
-                  <a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/martes.jpg">Inteligencia Artificial</a>
-                </span>
-              </span> –{" "}
-              <span style={{ textDecoration: 'underline' }}>
-                <span style={{ color: '#3366ff' }}>
-                  <a style={{ color: '#3366ff' }} href="https://blacks.university/wp-content/uploads/2025/04/miercoles.jpg">
-                    <span style={{ color: '#33cccc', textDecoration: 'underline' }}>Closer de Ventas</span>
-                  </a>
-                </span>
-              </span> –{" "}
-              <span style={{ textDecoration: 'underline' }}>
-                <span style={{ color: '#33cccc' }}>
-                  <a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/jueves.jpg">Creación y Ventas</a>
-                </span>
-              </span> –{" "}
-              <span style={{ color: '#33cccc' }}>
-                <a style={{ color: '#33cccc' }} href="https://blacks.university/wp-content/uploads/2025/04/viernes.jpg">
-                  <span style={{ textDecoration: 'underline' }}>Crafting</span>.
+    <section className="section-block section-block--panel">
+      <h2 className="section-block__heading">
+        Activa una cuenta en Blacks.University® recibe los siguientes beneficios:
+      </h2>
+      <div className="benefits-layout">
+        <ul>
+          <li>
+            Acceso <span className="benefits-highlight">para toda la vida</span> a las mentorías en vivo todos los días de lunes a viernes de 9:00 AM a 12:00 M hora Colombia.
+            <ul>
+              <li>
+                <span className="benefits-highlight">Lunes:</span>{' '}
+                <a className="link-inline" href="https://blacks.university/wp-content/uploads/2025/04/lunes.jpg" target="_blank" rel="noopener">
+                  Tráfico Pago
                 </a>
-              </span>
-            </li>
-          </ul>
-        </li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>para toda la vida</span> a la plataforma de Blacks.University® donde se encuentran publicadas las estrategias profesionales para vender productos digitales.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>para toda la vida</span> a la franquicia de Universidad.Online® donde podrás comercializar los programas educativos y las matrículas y ganar desde 140 dólares por venta inmediata y automáticamente.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>para toda la vida</span> a la franquicia de Blacks.University® donde podrás usar los ecosistemas y embudos para comercializar los accesos y ganar el 50% de comisión.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>para toda la vida</span> a las grabaciones en video de las mentorías de todos los días. Este es un recurso invaluable que construimos todos los días.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>ilimitado y para toda la vida</span> a la comunidad de usuarios activos donde podrás interactuar con los otros usuarios activos que están creando y/o vendiendo productos digitales con Hotmart®.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>ilimitado y para toda la vida</span> a más de 1.500 productos digitales listos para vender y ganar hasta el 80% de comisión a través de Hotmart®.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>ilimitado y para toda la vida</span> a los contenidos de los productos digitales para estudiarlos y vender mejor.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>ilimitado y para toda la vida</span> a las Master Classes profesionales creadas con personas que han hackeado en mercado de los productos digitales en habla hispana.</li>
-        <li>Acceso <span style={{ color: '#ffff00' }}>ilimitado y para toda la vida</span> a la comercialización de los NUEVOS programas educativos de Universidad.Online®.</li>
-        <li>Acceso a los <span style={{ color: '#ffff00' }}>exámenes de suficiencia académica</span> para recibir los diplomas de <span style={{ textDecoration: 'underline', color: '#33cccc' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/diplomas.jpg">Marketer Profesional, Closer de Ventas y Productor Digital.</a></span></li>
-      </ul>
-    </div>
+              </li>
+              <li>
+                <span className="benefits-highlight">Martes:</span>{' '}
+                <a className="link-inline" href="https://blacks.university/wp-content/uploads/2025/04/martes.jpg" target="_blank" rel="noopener">
+                  Inteligencia Artificial
+                </a>
+              </li>
+              <li>
+                <span className="benefits-highlight">Miércoles:</span>{' '}
+                <a className="link-inline" href="https://blacks.university/wp-content/uploads/2025/04/miercoles.jpg" target="_blank" rel="noopener">
+                  Closer de Ventas
+                </a>
+              </li>
+              <li>
+                <span className="benefits-highlight">Jueves:</span>{' '}
+                <a className="link-inline" href="https://blacks.university/wp-content/uploads/2025/04/jueves.jpg" target="_blank" rel="noopener">
+                  Creación y Ventas
+                </a>
+              </li>
+              <li>
+                <span className="benefits-highlight">Viernes:</span>{' '}
+                <a className="link-inline" href="https://blacks.university/wp-content/uploads/2025/04/viernes.jpg" target="_blank" rel="noopener">
+                  Crafting y Productos Digitales
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">para toda la vida</span> a la plataforma de Blacks.University® donde se encuentran publicadas las estrategias profesionales para vender productos digitales.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">para toda la vida</span> a la franquicia de Universidad.Online® donde podrás comercializar los programas educativos y ganar desde 140 dólares por venta inmediata y automáticamente.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">para toda la vida</span> a la franquicia de Blacks.University® donde podrás usar los ecosistemas y embudos para comercializar los accesos y ganar el 50% de comisión.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">para toda la vida</span> a las grabaciones en video de las mentorías de todos los días.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">ilimitado y para toda la vida</span> a la comunidad de usuarios activos donde podrás interactuar con quienes están creando y vendiendo productos digitales con Hotmart®.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">ilimitado y para toda la vida</span> a más de 1.500 productos digitales listos para vender y ganar hasta el 80% de comisión a través de Hotmart®.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">ilimitado y para toda la vida</span> a los contenidos de los productos digitales para estudiarlos y vender mejor.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">ilimitado y para toda la vida</span> a las Master Classes profesionales creadas por expertos del mercado hispano.
+          </li>
+          <li>
+            Acceso <span className="benefits-highlight">ilimitado y para toda la vida</span> a la comercialización de los nuevos programas educativos de Universidad.Online®.
+          </li>
+          <li>
+            Acceso a los <span className="benefits-highlight">exámenes de suficiencia académica</span> para recibir los diplomas de{' '}
+            <a className="link-inline" href="https://blacks.university/wp-content/uploads/2025/04/diplomas.jpg" target="_blank" rel="noopener">
+              Marketer Profesional, Closer de Ventas y Productor Digital
+            </a>
+            .
+          </li>
+        </ul>
+      </div>
+    </section>
   );
 };
 

--- a/src/components/CTAButton.tsx
+++ b/src/components/CTAButton.tsx
@@ -2,41 +2,17 @@ import React from 'react';
 
 const CTAButton = () => {
   return (
-    <div className="cta-sticky">
-      {/* Imagen de flecha */}
-      <div className="py-4">
-        <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-          <img 
-            loading="lazy" 
-            decoding="async" 
-            src="https://i0.wp.com/blacks.university/wp-content/uploads/2024/10/arrow-brushes-design-png-34.png?fit=252%2C300&amp;ssl=1" 
-            alt="" 
-            className="mx-auto"
-            style={{ width: '252px', height: '300px' }}
-          />
-        </a>
-      </div>
-      
-      {/* Texto de inscripciones */}
-      <div className="py-4">
-        <p style={{ textAlign: 'center' }}><strong>INSCRIPCIONES ABIERTAS HASTA HOY  <span style={{ color: '#ff0000' }}>Dom 28 septiembre</span> a las <span style={{ color: '#ff0000' }}>10:00 PM</span> hora Colombia</strong></p>
-      </div>
-      
-      {/* Botón CTA */}
-      <div className="py-6">
-        <div className="elementor-button-wrapper">
-          <a 
-            className="cta-button"
-            href="https://pay.hotmart.com/G99109427E?checkoutMode=10"
-          >
-            <span className="elementor-button-content-wrapper">
-              <span className="elementor-button-text">
-                CLICK AQUÍ PARA COMENZAR A VENDER NUESTROS PRODUCTOS DIGITALES Y GENERAR INGRESOS INMEDIATAMENTE...
-              </span>
-            </span>
-          </a>
-        </div>
-      </div>
+    <div className="cta-section section-block">
+      <img
+        className="cta-section__arrow"
+        src="https://i0.wp.com/blacks.university/wp-content/uploads/2024/10/arrow-brushes-design-png-34.png?fit=252%2C300&ssl=1"
+        alt="Flecha apuntando al botón de compra"
+        loading="lazy"
+      />
+
+      <a className="cta-section__link" href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
+        CLICK AQUÍ PARA COMENZAR A VENDER NUESTROS PRODUCTOS DIGITALES Y GENERAR INGRESOS INMEDIATAMENTE...
+      </a>
     </div>
   );
 };

--- a/src/components/CopyPasteHeadline.tsx
+++ b/src/components/CopyPasteHeadline.tsx
@@ -4,13 +4,11 @@ import React from 'react';
 
 const CopyPasteHeadline = () => {
   return (
-    <div className="py-6">
-      <h3 className="text-center text-2xl font-bold">
-        <span style={{ backgroundColor: '#ffff00', color: '#000000', padding: '0.5rem 0.5rem', borderRadius: '9999px' }}>
-          ÚNICAMENTE TIENES QUE COPIAR Y PEGAR PARA VENDER Y GANAR HOY MISMO...
-        </span>
-      </h3>
-    </div>
+    <section className="copy-headline section-block">
+      <span className="copy-headline__badge">
+        ÚNICAMENTE TIENES QUE COPIAR Y PEGAR PARA VENDER Y GANAR HOY MISMO...
+      </span>
+    </section>
   );
 };
 

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -11,56 +11,59 @@ const FAQSection = () => {
 
   const faqs = [
     {
-      question: "¿Por qué tantos beneficios de ALTÍSIMA CALIDAD por el precio de 50 dólares y para toda la vida?",
-      answer: "Ahora el modelo es diferente, más ajustado a la realidad y dinámica del mercado en habla hispana. Ahora Blacks.University® y Universidad.Online® CREA los programas educativos y los productos digitales y NECESITA URGENTEMENTE vendedores (afiliados) que los comercialicen masivamente por Internet. Nosotros estamos comprometidos entregando todo lo que cualquier persona que quiera vender nuestros programas y productos necesita saber, hacer y tener para generar ALTOS INGRESOS diariamente. En este momento un afiliado (vendedor) bien capacitado puede estar facturando aproximadamente de 2 mil a 4 mil dólares todos los días. Si nosotros le damos 50% u 80% de comisión en programas y/o productos, para nosotros el ingreso es representativo en el tiempo. El cobro de los 50 dólares es simbólico para que las personas se animen y tengan la seriedad, orden y disciplina de capacitarse con las estrategias básicas validadas y así salir a vender y ganar. Cuando los vendedores ganan ¡NOSOTROS GANAMOS!"
+      question: '¿Por qué tantos beneficios de ALTÍSIMA CALIDAD por el precio de 50 dólares y para toda la vida?',
+      answer:
+        'Ahora el modelo es diferente, más ajustado a la realidad y dinámica del mercado en habla hispana. Ahora Blacks.University® y Universidad.Online® CREA los programas educativos y los productos digitales y NECESITA URGENTEMENTE vendedores (afiliados) que los comercialicen masivamente por Internet. Nosotros estamos comprometidos entregando todo lo que cualquier persona que quiera vender nuestros programas y productos necesita saber, hacer y tener para generar ALTOS INGRESOS diariamente. En este momento un afiliado (vendedor) bien capacitado puede estar facturando aproximadamente de 2 mil a 4 mil dólares todos los días. Si nosotros le damos 50% u 80% de comisión en programas y/o productos, para nosotros el ingreso es representativo en el tiempo. El cobro de los 50 dólares es simbólico para que las personas se animen y tengan la seriedad, orden y disciplina de capacitarse con las estrategias básicas validadas y así salir a vender y ganar. Cuando los vendedores ganan ¡NOSOTROS GANAMOS!',
     },
     {
-      question: "¿Tengo que a pagar adicional y/o posteriormente por los beneficios ofrecidos en Blacks.University®?",
-      answer: "NO. Realmente el pago de los 50 dólares es un precio simbólico PARA TODA LA VIDA. Sin cargos adicionales ni posteriores NUNCA MÁS."
+      question: '¿Tengo que a pagar adicional y/o posteriormente por los beneficios ofrecidos en Blacks.University®?',
+      answer:
+        'NO. Realmente el pago de los 50 dólares es un precio simbólico PARA TODA LA VIDA. Sin cargos adicionales ni posteriores NUNCA MÁS.',
     },
     {
-      question: "¿Cuáles son todos los beneficios que voy a recibir para toda la vida si entro a Blacks.University®?",
-      answer: "Los siguientes son todos los beneficios que vas a recibir cuando ingresas al equipo de vendedores de Blacks.University®. 1. Acceso ilimitado y PARA TODA LA VIDA a la plataforma de Blacks.University®. Ahí puedes encontrar las estrategias e instrucciones para copiar y pegar, vender y ganar. 2. Acceso ilimitado y PARA TODA LA VIDA a las sesiones de mentoría todos los días. También puedes acceder para toda la vida a las grabaciones de las mismas. 3. Acceso ilimitado y PARA TODA LA VIDA a la comunidad de usuarios activos de Blacks.University®. Podrás interactuar con todas las personas que están creando y/o vendiendo productos digitales con Hotmart®. 4. Acceso ilimitado y PARA TODA LA VIDA a la franquicia educativa digital de Universidad.Online® que te permite vender las matrículas, programas educativos y productos digitales. 5. Acceso ilimitado y PARA TODA LA VIDA a la franquicia de Blacks.University® que te permitirá vender los accesos a la plataforma usando nuestros ecosistemas y embudos validados. 6. Acceso ilimitado y PARA TODA LA VIDA a los exámenes de suficiencia académica y diplomas de Marketer Profesional, Closer de Ventas y Productor Digital homologables posteriormente con Florida Global University. 7. Acceso ilimitado y PARA TODA LA VIDA a más de 1.500 productos digitales en todas las categorías. Podrás ver el contenido de cada uno, analizar y verificar los ángulos de ventas y así estar mucho más seguro de lo que vas a vender. 8. Acceso ilimitado y PARA TODA LA VIDA a la afiliación de más de 1.500 productos digitales para ganar directa y automáticamente hasta el 80% de comisión a través de la plataforma de Hotmart®."
+      question: '¿Cuáles son todos los beneficios que voy a recibir para toda la vida si entro a Blacks.University®?',
+      answer:
+        'Los siguientes son todos los beneficios que vas a recibir cuando ingresas al equipo de vendedores de Blacks.University®. 1. Acceso ilimitado y PARA TODA LA VIDA a la plataforma de Blacks.University®. Ahí puedes encontrar las estrategias e instrucciones para copiar y pegar, vender y ganar. 2. Acceso ilimitado y PARA TODA LA VIDA a las sesiones de mentoría todos los días. También puedes acceder para toda la vida a las grabaciones de las mismas. 3. Acceso ilimitado y PARA TODA LA VIDA a la comunidad de usuarios activos de Blacks.University®. Podrás interactuar con todas las personas que están creando y/o vendiendo productos digitales con Hotmart®. 4. Acceso ilimitado y PARA TODA LA VIDA a la franquicia educativa digital de Universidad.Online® que te permite vender las matrículas, programas educativos y productos digitales. 5. Acceso ilimitado y PARA TODA LA VIDA a la franquicia de Blacks.University® que te permitirá vender los accesos a la plataforma usando nuestros ecosistemas y embudos validados. 6. Acceso ilimitado y PARA TODA LA VIDA a los exámenes de suficiencia académica y diplomas de Marketer Profesional, Closer de Ventas y Productor Digital homologables posteriormente con Florida Global University. 7. Acceso ilimitado y PARA TODA LA VIDA a más de 1.500 productos digitales en todas las categorías. Podrás ver el contenido de cada uno, analizar y verificar los ángulos de ventas y así estar mucho más seguro de lo que vas a vender. 8. Acceso ilimitado y PARA TODA LA VIDA a la afiliación de más de 1.500 productos digitales para ganar directa y automáticamente hasta el 80% de comisión a través de la plataforma de Hotmart®.',
     },
     {
-      question: "¿Por qué Mauricio GARANTIZA los ingresos (dinero) vendiendo productos digitales con Hotmart®?",
-      answer: "¡Así es! Mauricio GARANTIZA los resultados (ingresos) porque aquí tu vienes a usar nuestros ecosistemas, embudos y productos que ya están creados, funcionando y vendiéndose todos los días en todo momento. Aquí vienes a COPIAR y PEGAR para VENDER y GANAR. ¿Estás listo? <span style=\"text-decoration: underline;\"><span style=\"color: #3366ff;\"><a style=\"color: #3366ff; text-decoration: underline;\" href=\"https://pay.hotmart.com/G99109427E\" target=\"_blank\" rel=\"noopener\">Click aquí para ingresar al equipo.</a></span></span>"
+      question: '¿Por qué Mauricio GARANTIZA los ingresos (dinero) vendiendo productos digitales con Hotmart®?',
+      answer:
+        '¡Así es! Mauricio GARANTIZA los resultados (ingresos) porque aquí tu vienes a usar nuestros ecosistemas, embudos y productos que ya están creados, funcionando y vendiéndose todos los días en todo momento. Aquí vienes a COPIAR y PEGAR para VENDER y GANAR. ¿Estás listo? <span style="text-decoration: underline;"><span style="color: #3366ff;"><a style="color: #3366ff; text-decoration: underline;" href="https://pay.hotmart.com/G99109427E" target="_blank" rel="noopener">Click aquí para ingresar al equipo.</a></span></span>',
     },
     {
-      question: "¿Cuáles son cada uno de los temas, expertos, días y horarios de las mentorías de Blacks.University®?",
-      answer: "Las mentorías de Blacks.University® funcionan todos los días de lunes a viernes de 9:00 AM a 12:00 M hora Colombia. <ul><li><span style=\"color: #ffff00;\"><strong>Lunes:</strong> </span>Mentoría de tráfico pago con <span style=\"color: #3366ff;\"><a style=\"color: #3366ff;\" href=\"https://blacks.university/wp-content/uploads/2025/04/lunes.jpg\">Marcos Araujo.</a></span></li><li><span style=\"color: #ffff00;\"><strong>Martes:</strong></span> Mentoría de Inteligencia Artificial con <span style=\"color: #3366ff;\"><a style=\"color: #3366ff;\" href=\"https://blacks.university/wp-content/uploads/2025/04/martes.jpg\">Kike Cadena.</a></span></li><li><span style=\"color: #ffff00;\"><strong>Miércoles:</strong></span> Closer de Ventas con <span style=\"color: #3366ff;\"><a style=\"color: #3366ff;\" href=\"https://blacks.university/wp-content/uploads/2025/04/miercoles.jpg\">Diana Aragón.</a></span></li><li><span style=\"color: #ffff00;\"><strong>Jueves:</strong></span> Creación y Ventas de Productos Digitales con <span style=\"color: #3366ff;\"><a style=\"color: #3366ff;\" href=\"https://blacks.university/wp-content/uploads/2025/04/jueves.jpg\">Mauricio Duque.</a></span></li><li><span style=\"color: #ffff00;\"><strong>Viernes:</strong> </span>Diseño y desarrollo de productos digitales con <span style=\"color: #3366ff;\"><a style=\"color: #3366ff;\" href=\"https://blacks.university/wp-content/uploads/2025/04/viernes.jpg\">Nino Scarpato.</a></span></li></ul>"
+      question: '¿Cuáles son cada uno de los temas, expertos, días y horarios de las mentorías de Blacks.University®?',
+      answer:
+        'Las mentorías de Blacks.University® funcionan todos los días de lunes a viernes de 9:00 AM a 12:00 M hora Colombia. <ul><li><span style="color: #ffff00;"><strong>Lunes:</strong> </span>Mentoría de tráfico pago con <span style="color: #3366ff;"><a style="color: #3366ff;" href="https://blacks.university/wp-content/uploads/2025/04/lunes.jpg">Marcos Araujo.</a></span></li><li><span style="color: #ffff00;"><strong>Martes:</strong></span> Mentoría de Inteligencia Artificial con <span style="color: #3366ff;"><a style="color: #3366ff;" href="https://blacks.university/wp-content/uploads/2025/04/martes.jpg">Kike Cadena.</a></span></li><li><span style="color: #ffff00;"><strong>Miércoles:</strong></span> Closer de Ventas con <span style="color: #3366ff;"><a style="color: #3366ff;" href="https://blacks.university/wp-content/uploads/2025/04/miercoles.jpg">Diana Aragón.</a></span></li><li><span style="color: #ffff00;"><strong>Jueves:</strong></span> Creación y Ventas de Productos Digitales con <span style="color: #3366ff;"><a style="color: #3366ff;" href="https://blacks.university/wp-content/uploads/2025/04/jueves.jpg">Mauricio Duque.</a></span></li><li><span style="color: #ffff00;"><strong>Viernes:</strong> </span>Diseño y desarrollo de productos digitales con <span style="color: #3366ff;"><a style="color: #3366ff;" href="https://blacks.university/wp-content/uploads/2025/04/viernes.jpg">Nino Scarpato.</a></span></li></ul>',
     },
     {
-      question: "¿Cuáles son las múltiples formas de ganar dinero con Blacks.University®?",
-      answer: "Es muy importante tener el fin en la mente <strong>MUY CLARO.</strong> NO vienes a Blacks.University® a aprender, vienes a Blacks.University® <strong>A GANAR DINERO.</strong> Sencillamente porque tanto los productos como los ecosistemas y embudos ya están creados, automatizados y funcionando. Ya los productos se están vendiendo todos los días. Simplemente hay que <strong>ENTENDER</strong> como funcionan y <strong>COPIAR</strong> y <strong>PEGAR</strong> para <strong>VENDER</strong> y <strong>GANAR.</strong> Las siguientes son las 7 formas de generar ingresos que tiene Blacks.University® y están incluídos como beneficios <span style=\"color: #ffff00;\">PARA TODA LA VIDA</span> cuando realizas el ingreso pagando únicamente 50 dólares. <ol><li>Vendiendo el producto recomendado.<ul><li>Con este producto podemos garantizar tus ingresos desde hoy mismo. De forma automática y manual.</li></ul></li><li>Vender los productos del catálogo de Universidad.Online®.<ul><li>De forma manual y automática.</li></ul></li><li>Vender los programas educativos de Universidad.Online®.<ul><li>De forma manual.</li></ul></li><li>Vender las matrículas vitalicias de Universidad.Online®.<ul><li>De forma manual.</li></ul></li><li>Vender tu propio producto digital.<ul><li>De forma manual y automática.</li></ul></li><li>Prestar servicios.<ul><li>Asesoría, consultoría, diseño, desarrollo, producción.</li></ul></li><li>COproducciones.<ul><li>Sociedades con los productores.</li></ul></li></ol>"
-    }
+      question: '¿Cuáles son las múltiples formas de ganar dinero con Blacks.University®?',
+      answer:
+        'Es muy importante tener el fin en la mente <strong>MUY CLARO.</strong> NO vienes a Blacks.University® a aprender, vienes a Blacks.University® <strong>A GANAR DINERO.</strong> Sencillamente porque tanto los productos como los ecosistemas y embudos ya están creados, automatizados y funcionando. Ya los productos se están vendiendo todos los días. Simplemente hay que <strong>ENTENDER</strong> como funcionan y <strong>COPIAR</strong> y <strong>PEGAR</strong> para <strong>VENDER</strong> y <strong>GANAR.</strong> Las siguientes son las 7 formas de generar ingresos que tiene Blacks.University® y están incluídos como beneficios <span style="color: #ffff00;">PARA TODA LA VIDA</span> cuando realizas el ingreso pagando únicamente 50 dólares. <ol><li>Vendiendo el producto recomendado.<ul><li>Con este producto podemos garantizar tus ingresos desde hoy mismo. De forma automática y manual.</li></ul></li><li>Vender los productos del catálogo de Universidad.Online®.<ul><li>De forma manual y automática.</li></ul></li><li>Vender los programas educativos de Universidad.Online®.<ul><li>De forma manual.</li></ul></li><li>Vender las matrículas vitalicias de Universidad.Online®.<ul><li>De forma manual.</li></ul></li><li>Vender tu propio producto digital.<ul><li>De forma manual y automática.</li></ul></li><li>Prestar servicios.<ul><li>Asesoría, consultoría, diseño, desarrollo, producción.</li></ul></li><li>COproducciones.<ul><li>Sociedades con los productores.</li></ul></li></ol>',
+    },
   ];
 
   return (
-    <div className="py-8">
-      <div className="py-4">
-        <p style={{ textAlign: 'center' }}>RESPUESTAS A PREGUNTAS FRECUENTES</p>
-      </div>
-      <div className="space-y-4">
+    <section className="section-block section-block--panel">
+      <h2 className="section-block__heading">RESPUESTAS A PREGUNTAS FRECUENTES</h2>
+      <div className="faq-list">
         {faqs.map((faq, index) => (
-          <div key={index} className="border border-gray-300 rounded-lg">
+          <div className="faq-item" key={faq.question}>
             <button
-              className="w-full text-left p-4 hover:bg-gray-200 focus:outline-none flex justify-between items-center"
-              style={{ backgroundColor: '#f0f0f0' }}
+              className="faq-question"
               onClick={() => toggleAccordion(index)}
+              aria-expanded={openIndex === index}
+              aria-controls={`faq-panel-${index}`}
             >
-              <span className="font-medium" style={{ color: '#000000' }}>{faq.question}</span>
-              <span className="text-xl">{openIndex === index ? '-' : '+'}</span>
+              <span>{faq.question}</span>
+              <span>{openIndex === index ? '-' : '+'}</span>
             </button>
             {openIndex === index && (
-              <div className="p-4" style={{ backgroundColor: '#ffffff' }}>
-                <p dangerouslySetInnerHTML={{ __html: faq.answer }} />
-              </div>
+              <div id={`faq-panel-${index}`} className="faq-answer" dangerouslySetInnerHTML={{ __html: faq.answer }} />
             )}
           </div>
         ))}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,36 +2,28 @@ import React from 'react';
 
 const Footer = () => {
   return (
-    <div className="py-8 text-center">
-      {/* Logos de partners */}
-      <div className="py-4">
-        <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-          <img 
-            loading="lazy" 
-            decoding="async" 
-            src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/04/logos.png?fit=800%2C219&amp;ssl=1" 
-            alt="" 
-            className="mx-auto"
-            style={{ width: '800px', height: '219px' }}
-          />
-        </a>
-      </div>
-      
-      {/* Información de contacto */}
-      <div className="py-4">
-        <h3 style={{ textAlign: 'center' }}>Mauricio Duque Zuluaga</h3>
-        <p style={{ textAlign: 'center' }}>
-          Principal en Seminarios.Online® – Blacks.University® – Universidad.Online®.<br />
-          Avenida 4 Norte # 7N – 46 Cali Colombia.
+    <footer className="footer-block">
+      <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10" target="_blank" rel="noopener">
+        <img
+          loading="lazy"
+          decoding="async"
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/04/logos.png?fit=800%2C219&ssl=1"
+          alt="Aliados Blacks.University"
+        />
+      </a>
+
+      <div>
+        <h3>Mauricio Duque Zuluaga</h3>
+        <p>
+          Principal en Seminarios.Online® – Blacks.University® – Universidad.Online®<br />
+          Avenida 4 Norte # 7N – 46 Cali, Colombia.
         </p>
-        <p style={{ textAlign: 'center' }}>
-          Suite 400, Lake Nona Town Center, Tavistock Lakes Blvd, Orlando, FL 32827
-        </p>
-        <p style={{ textAlign: 'center' }}>
-          contacto: <span style={{ color: '#ffff00' }}>soporte@blacks.university</span>
+        <p>Suite 400, Lake Nona Town Center, Tavistock Lakes Blvd, Orlando, FL 32827.</p>
+        <p>
+          contacto: <span className="contact-highlight">soporte@blacks.university</span>
         </p>
       </div>
-    </div>
+    </footer>
   );
 };
 

--- a/src/components/GuaranteeBanner.tsx
+++ b/src/components/GuaranteeBanner.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 
 const GuaranteeBanner = () => {
   return (
-    <div className="py-4">
-      <p className="text-center">
-        «Factura mínimo 300 dólares semanales <span style={{ color: '#ff0000' }}>GARANTIZADO</span> comenzando <span style={{ color: '#ffff00' }}>HOY MISMO</span> vendiendo nuestros más de 1.500 Productos Digitales a través de Hotmart®…»
-      </p>
-    </div>
+    <section className="hero-claim section-block">
+      «Factura mínimo 300 dólares semanales <strong>GARANTIZADO</strong> comenzando{' '}
+      <span>HOY MISMO</span> vendiendo nuestros más de 1.500 Productos Digitales a través de Hotmart®…»
+    </section>
   );
 };
 

--- a/src/components/HotmartLogo.tsx
+++ b/src/components/HotmartLogo.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 
 const HotmartLogo = () => {
   return (
-    <div className="text-center py-4">
-      <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-        <img 
-          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/06/hotmartuologos.png?fit=565%2C93&ssl=1" 
-          alt="Hotmart Logo" 
-          className="mx-auto"
-          style={{ width: '565px', height: '93px' }}
+    <section className="logo-strip section-block">
+      <div className="logo-strip__row">
+        <img
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/06/universidad-online-logo.png?resize=260%2C80&ssl=1"
+          alt="Universidad Online"
+          className="logo-strip__brand"
         />
-      </a>
-    </div>
+        <span className="logo-strip__separator" aria-hidden="true" />
+        <img
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/06/hotmart-powered-logo.png?resize=260%2C80&ssl=1"
+          alt="Powered by Hotmart"
+          className="logo-strip__brand"
+        />
+      </div>
+      <p className="logo-strip__caption">
+        USAMOS ACTIVOS VIRTUALES COMO HOTMART, REDES SOCIALES Y LA UNIVERSIDAD ONLINE PARA CREAR INGRESOS 100% DIGITALES.
+      </p>
+    </section>
   );
 };
 

--- a/src/components/InstructorInfo.tsx
+++ b/src/components/InstructorInfo.tsx
@@ -1,87 +1,185 @@
 import React from 'react';
 
+const mentors = [
+  {
+    name: 'Mauricio Duque',
+    role: 'Director Blacks.University®',
+    photo: 'https://blacks.university/wp-content/uploads/2025/04/jueves.jpg',
+  },
+  {
+    name: 'Marcos Araujo',
+    role: 'Tráfico Pago',
+    photo: 'https://blacks.university/wp-content/uploads/2025/04/lunes.jpg',
+  },
+  {
+    name: 'Kike Cadena',
+    role: 'Inteligencia Artificial',
+    photo: 'https://blacks.university/wp-content/uploads/2025/04/martes.jpg',
+  },
+  {
+    name: 'Diana Aragón',
+    role: 'Closer Digital Profesional',
+    photo: 'https://blacks.university/wp-content/uploads/2025/04/miercoles.jpg',
+  },
+  {
+    name: 'Nino Scarpato',
+    role: 'Diseño y Crafting Digital',
+    photo: 'https://blacks.university/wp-content/uploads/2025/04/viernes.jpg',
+  },
+];
+
 const InstructorInfo = () => {
   return (
-    <div className="py-8">
-      {/* Imagen del equipo */}
-      <div className="text-center py-4">
-        <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-          <img 
-            loading="lazy" 
-            decoding="async" 
-            src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/05/equipo.jpg?fit=800%2C317&amp;ssl=1" 
-            alt="" 
-            className="mx-auto"
-            style={{ width: '800px', height: '317px' }}
-          />
-        </a>
+    <section className="section-block">
+      <div className="mentors-banner">
+        <h2 className="mentors-banner__heading">MENTORÍA PARA TODA LA VIDA</h2>
+        <span className="section-block__subtext">Hotmart® para toda la vida.</span>
+        <div className="mentor-cards">
+          {mentors.map((mentor) => (
+            <div className="mentor-card" key={mentor.name}>
+              <img className="mentor-card__photo" src={mentor.photo} alt={mentor.name} loading="lazy" />
+              <h4>{mentor.name}</h4>
+              <p>{mentor.role}</p>
+            </div>
+          ))}
+        </div>
       </div>
-      
-      {/* Información de Mauricio Duque */}
-      <div className="py-4">
-        <h1 style={{ textAlign: 'center' }}><strong>¿</strong>Quién es Mauricio Duque y por qué puede ayudarle?</h1>
+
+      <img
+        className="team-photo"
+        loading="lazy"
+        decoding="async"
+        src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/05/equipo.jpg?fit=800%2C317&ssl=1"
+        alt="Equipo Blacks.University"
+      />
+
+      <div className="bio-section">
+        <h3>¿Quién es Mauricio Duque y por qué puede ayudarle?</h3>
         <p>
-          Mauricio Duque lleva 30 años trabajando por Internet y 23 (de los 30) dedicado a la creación y comercialización de educación por Internet.
+          Mauricio Duque lleva 30 años trabajando por Internet y 23 de ellos dedicados a la creación y comercialización de
+          educación en línea.
         </p>
         <p>
-          Mauricio tiene como profesión Administrador de Negocios de la Universidad de Sanbuenaventura Cali, <span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/Andes.jpg">especialista en eCommerce de la Universidad de Los Andes,</a></span></span> Especialista en derecho de las Telecomunicaciones y TICs en Colombia.
+          Es Administrador de Negocios de la Universidad de Sanbuenaventura Cali y{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/05/Andes.jpg" target="_blank" rel="noopener">
+            especialista en eCommerce de la Universidad de Los Andes
+          </a>{' '}
+          además de especialista en Derecho de las Telecomunicaciones y TICs en Colombia.
         </p>
         <p>
-          Cuenta con múltiples certificaciones, cursos, talleres, seminarios e iniciativas muy existosas en la industria de la creación y comercialización de educación por Internet en habla hispana.
+          Cuenta con múltiples certificaciones, cursos, talleres y seminarios exitosos en la industria de la educación digital
+          en habla hispana.
         </p>
         <p>
-          Mauricio a creado proyectos como Seminarios.Online® alcanzando una facturación record de más de 77 millones de dólares (GMV) en poco más de 4 años y Universidad.Online® que hoy en día tiene más de 150 mil estudiantes activos.
+          Mauricio ha creado proyectos como Seminarios.Online® alcanzando una facturación récord de más de 77 millones de dólares
+          (GMV) en poco más de 4 años y Universidad.Online® con más de 150 mil estudiantes activos.
         </p>
         <p>
-          Actualmente lidera el proyecto Universidad.Online® y Blacks.University®, que búsca promover la técnica de la afiliación como modelo de negocio y trabajo como solución a la empleabilidad en países de habla hispana.
+          Actualmente lidera Universidad.Online® y Blacks.University®, promoviendo la afiliación como modelo de negocio y
+          respuesta a la empleabilidad en países de habla hispana.
         </p>
       </div>
-      
-      {/* Premios de Mauricio Duque */}
-      <div className="py-4">
-        <h1 style={{ textAlign: 'center' }}>Mauricio Duque ha recibido 14 premios Hotmart®:</h1>
+
+      <div className="bio-section">
+        <h3>Mauricio Duque ha recibido 14 premios Hotmart®</h3>
         <ul>
-          <li><span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg">3 Premios Hotmart® Galaxy 3 años consecutivos.</a></span></span></li>
-          <li><span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg">6 Premios Hotmart® Black (Para 1.200.000 dólares de ingreso neto).</a></span></span></li>
-          <li><span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg">3 Premios Hotmart® Moon (Para 3 millones de dólares de ingreso neto).</a></span></span></li>
-          <li><span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg">2 Premios Hotmart® Venus (Para 4 millones de dólares de ingreso neto).</a></span></span></li>
+          <li>
+            <a href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg" target="_blank" rel="noopener">
+              3 Premios Hotmart® Galaxy por 3 años consecutivos
+            </a>
+          </li>
+          <li>
+            <a href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg" target="_blank" rel="noopener">
+              6 Premios Hotmart® Black (1.200.000 dólares de ingreso neto)
+            </a>
+          </li>
+          <li>
+            <a href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg" target="_blank" rel="noopener">
+              3 Premios Hotmart® Moon (3 millones de dólares de ingreso neto)
+            </a>
+          </li>
+          <li>
+            <a href="https://blacks.university/wp-content/uploads/2025/04/fotoPremios.jpg" target="_blank" rel="noopener">
+              2 Premios Hotmart® Venus (4 millones de dólares de ingreso neto)
+            </a>
+          </li>
         </ul>
       </div>
-      
-      {/* Reconocimientos y eventos */}
-      <div className="py-4">
+
+      <div className="bio-section">
         <p>
-          Mauricio Duque Zuluaga también ha sido invitado como conferencista en <span style={{ color: '#3366ff' }}><a style={{ color: '#3366ff' }} href="https://blacks.university/wp-content/uploads/2025/04/mdz.jpg"><span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}>múltiples eventos internacionales y congresos a nivel mundial</span>.</span></a></span> Muchos medios de comunicación de varios países han destacado su trabajo y su trayectoria. Por ejemplo: <span style={{ textDecoration: 'underline', color: '#33cccc' }}><span style={{ textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/04/forbes.jpg">Forbes</a></span></span>, <span style={{ color: '#3366ff' }}><span style={{ color: '#33cccc' }}><a style={{ color: '#33cccc' }} href="https://blacks.university/wp-content/uploads/2025/04/europapress.jpg"><span style={{ textDecoration: 'underline' }}>EuropaPress</span>,</a> </span><a style={{ color: '#3366ff' }} href="https://blacks.university/wp-content/uploads/2024/10/rs.jpg"><span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}>Revista Semana</span></span></a></span> en Colombia, <span style={{ textDecoration: 'underline', color: '#33cccc' }}><a style={{ color: '#33cccc' }} href="https://blacks.university/wp-content/uploads/2025/04/espectador.jpg"><span style={{ textDecoration: 'underline' }}>Diario El Espectador</span></a> </span>en Colombia, <span style={{ textDecoration: 'underline' }}><span style={{ color: '#3366ff' }}><a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2024/10/mercurio.jpg"><span style={{ color: '#33cccc', textDecoration: 'underline' }}>Diario El Mercurio en Chile</span></a></span></span>, <span style={{ textDecoration: 'underline' }}><span style={{ color: '#3366ff' }}><a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2024/10/yahoo.jpg"><span style={{ color: '#33cccc', textDecoration: 'underline' }}>Yahoo Finanzas para Latam</span></a></span></span>, <span style={{ textDecoration: 'underline' }}><span style={{ color: '#3366ff' }}><a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2024/10/emprendedoresdehoy.jpg"><span style={{ color: '#33cccc', textDecoration: 'underline' }}>Revista Emprendedores de Hoy</span></a></span></span> en México, <span style={{ textDecoration: 'underline', color: '#33cccc' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2024/10/ccc.jpg">Cámara de Comercio de Cali</a></span> entre muchas otras.
+          Mauricio Duque Zuluaga ha sido invitado como conferencista en{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/04/mdz.jpg" target="_blank" rel="noopener">
+            múltiples eventos internacionales y congresos
+          </a>
+          . Su trabajo ha sido destacado en medios como{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/04/forbes.jpg" target="_blank" rel="noopener">
+            Forbes
+          </a>
+          ,{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/04/europapress.jpg" target="_blank" rel="noopener">
+            EuropaPress
+          </a>
+          ,{' '}
+          <a href="https://blacks.university/wp-content/uploads/2024/10/rs.jpg" target="_blank" rel="noopener">
+            Revista Semana
+          </a>
+          ,{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/04/espectador.jpg" target="_blank" rel="noopener">
+            Diario El Espectador
+          </a>
+          ,{' '}
+          <a href="https://blacks.university/wp-content/uploads/2024/10/mercurio.jpg" target="_blank" rel="noopener">
+            Diario El Mercurio (Chile)
+          </a>
+          ,{' '}
+          <a href="https://blacks.university/wp-content/uploads/2024/10/yahoo.jpg" target="_blank" rel="noopener">
+            Yahoo Finanzas Latam
+          </a>{' '}
+          y{' '}
+          <a href="https://blacks.university/wp-content/uploads/2024/10/emprendedoresdehoy.jpg" target="_blank" rel="noopener">
+            Revista Emprendedores de Hoy
+          </a>
+          , entre otros.
         </p>
         <p>
-          Mauricio Duque recibió el <span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/photo_2022-12-04_11-18-51.jpg">premio 40 en 7</a></span></span> por lograr una facturación de más de 1 millón de dólares en 7 días durante 11 meses consecutivos.
+          Recibió el{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/05/photo_2022-12-04_11-18-51.jpg" target="_blank" rel="noopener">
+            premio 40 en 7
+          </a>{' '}
+          por facturar más de 1 millón de dólares en 7 días durante 11 meses consecutivos.
         </p>
         <p>
-          Además Mauricio Duque es parte del equipo de las 25 empresas más grandes del mundo en el mercado de Hotmart®. Ha recibido el premio <span style={{ textDecoration: 'underline', color: '#33cccc' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/galaxy.jpg">Hotmart® Galaxy</a></span> durante 3 años consecutivos.
+          Además, es parte del selecto grupo de las 25 empresas más grandes del mundo en el mercado de Hotmart® y ha recibido el{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/05/galaxy.jpg" target="_blank" rel="noopener">
+            premio Hotmart® Galaxy
+          </a>{' '}
+          durante 3 años consecutivos.
         </p>
       </div>
-      
-      {/* Video y reconocimientos adicionales */}
-      <div className="py-4">
-        <div className="text-center py-4">
-          <div className="elementor-wrapper elementor-open-inline mx-auto" style={{ maxWidth: '800px' }}>
-            <iframe 
-              className="elementor-video-iframe" 
-              allowFullScreen 
-              allow="clipboard-write" 
-              title="Reproductor de vídeo videopress" 
-              src="https://videopress.com/embed/VPepnCAO?at&amp;controls=1&amp;autoPlay=0&amp;muted=0&amp;loop=0&amp;playsinline=0"
-              style={{ width: '100%', height: '450px' }}
-            ></iframe>
-          </div>
+
+      <div className="bio-section">
+        <div className="media-frame">
+          <iframe
+            allowFullScreen
+            allow="clipboard-write"
+            title="Reproductor de vídeo videopress"
+            src="https://videopress.com/embed/VPepnCAO?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0"
+          ></iframe>
         </div>
-        <div className="py-4">
-          <p style={{ textAlign: 'center' }}>
-            Mauricio también ha recibido los premios <span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/galaxy.jpg">Hotmart® Galaxy</a></span></span> y <span style={{ textDecoration: 'underline' }}><span style={{ color: '#33cccc', textDecoration: 'underline' }}><a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/photo_2024-07-09_21-01-08.jpg">Hotmart® Explorers</a></span></span> por su facturación transformación y desempeño en el mercado de habla hispana.
-          </p>
-        </div>
+        <p>
+          Mauricio también ha recibido los premios{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/05/galaxy.jpg" target="_blank" rel="noopener">
+            Hotmart® Galaxy
+          </a>{' '}
+          y{' '}
+          <a href="https://blacks.university/wp-content/uploads/2025/05/photo_2024-07-09_21-01-08.jpg" target="_blank" rel="noopener">
+            Hotmart® Explorers
+          </a>{' '}
+          por su transformación y desempeño en el mercado de habla hispana.
+        </p>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/LandingHeader.tsx
+++ b/src/components/LandingHeader.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 const LandingHeader = () => {
   return (
-    <div className="header-sticky">
-      <div className="container mx-auto px-4 py-2">
-        <p className="text-center font-bold">
-          <span style={{ color: '#000000' }}>INSCRIPCIONES ABIERTAS HASTA HOY</span> <span style={{ color: '#ff0000' }}>Dom 28 septiembre</span> a las <span style={{ color: '#ff0000' }}>10:00 PM</span> hora Colombia
-        </p>
+    <header className="top-banner">
+      <div className="top-banner__inner">
+        INSCRIPCIONES ABIERTAS HASTA HOY{' '}
+        <span className="top-banner__highlight">Dom 28 septiembre</span> a las{' '}
+        <span className="top-banner__highlight">10:00 PM</span> hora Colombia
       </div>
-    </div>
+    </header>
   );
 };
 

--- a/src/components/ProductImage.tsx
+++ b/src/components/ProductImage.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 
 const ProductImage = () => {
   return (
-    <div className="py-4">
+    <section className="product-strip section-block">
       <a href="https://pay.hotmart.com/G99109427E?checkoutMode=10">
-        <img 
-          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/04/pdhtm.jpg?fit=1425%2C287&ssl=1" 
-          alt="Producto" 
-          className="mx-auto"
-          style={{ width: '800px', height: '161px' }}
+        <img
+          src="https://i0.wp.com/blacks.university/wp-content/uploads/2025/04/pdhtm.jpg?fit=1425%2C287&ssl=1"
+          alt="Colección de productos digitales"
+          loading="lazy"
         />
       </a>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/PromoVideo.tsx
+++ b/src/components/PromoVideo.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 
 const PromoVideo = () => {
   return (
-    <div className="py-6">
-      <div className="elementor-wrapper elementor-open-inline">
-        <iframe 
-          className="elementor-video-iframe" 
-          allowFullScreen 
-          allow="clipboard-write" 
-          title="Reproductor de vídeo videopress" 
+    <section className="section-block">
+      <div className="media-frame">
+        <iframe
+          allowFullScreen
+          allow="clipboard-write"
+          title="Reproductor de vídeo videopress"
           src="https://videopress.com/embed/A1Ujuv02?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0"
-          style={{ width: '100%', height: '400px' }}
         ></iframe>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/SalesStats.tsx
+++ b/src/components/SalesStats.tsx
@@ -2,61 +2,37 @@ import React from 'react';
 
 const SalesStats = () => {
   return (
-    <div className="py-6">
-      <h3 className="text-center text-xl font-bold py-2">
+    <section className="section-block section-block--panel">
+      <h3 className="section-block__heading">
         VENTAS DÍAS RANDOM (ANALIZA LAS COLUMNAS DE PRODUCTOS, VENDEDORES Y FECHAS)
       </h3>
-      <p className="text-center py-2">
+      <p className="section-block__subtext">
         POR DIRECTRIZ DE HOTMART® DEBEMOS OCULTAR LA INFORMACIÓN DE LA TRANSACCIÓN Y NOMBRE DEL VENDEDOR
       </p>
-      <p className="text-center py-2">
-        <span style={{ textDecoration: 'underline', color: '#33cccc' }}>
-          <a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/nuevas.jpg">
-            15 mayo 2025
-          </a>
-        </span> –{" "}
-        <span style={{ color: '#33cccc' }}>
-          <span style={{ textDecoration: 'underline' }}>
-            <a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/gente2.jpg">
-              9 mayo 2025
-            </a>
-          </span> –{" "}
-        </span>
-        <a href="https://blacks.university/wp-content/uploads/2025/05/001-1.jpg">
-          <span style={{ textDecoration: 'underline' }}>
-            <span style={{ color: '#33cccc', textDecoration: 'underline' }}>14 enero 2025</span>
-          </span>
-        </a>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#33cccc', textDecoration: 'underline' }}>
-            <a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/002-1.jpg">
-              1 febrero 2025
-            </a>
-          </span>
-        </span>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <a href="https://blacks.university/wp-content/uploads/2025/05/003-1.jpg">
-            <span style={{ color: '#33cccc', textDecoration: 'underline' }}>1 marzo 2025</span>
-          </a>
-        </span>{" "}
-        –{" "}
-        <a href="https://blacks.university/wp-content/uploads/2025/05/004-1.jpg">
-          <span style={{ color: '#33cccc' }}>
-            <span style={{ textDecoration: 'underline' }}>1 abril 2025</span>
-          </span>
-        </a>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#33cccc', textDecoration: 'underline' }}>
-            <a style={{ color: '#33cccc', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/005-1.jpg">
-              1 mayo 2025
-            </a>
-          </span>
-        </span>
-      </p>
-    </div>
+      <div className="stat-links">
+        <a href="https://blacks.university/wp-content/uploads/2025/05/nuevas.jpg" target="_blank" rel="noopener">
+          15 mayo 2025
+        </a>
+        <a href="https://blacks.university/wp-content/uploads/2025/05/gente2.jpg" target="_blank" rel="noopener">
+          9 mayo 2025
+        </a>
+        <a href="https://blacks.university/wp-content/uploads/2025/05/001-1.jpg" target="_blank" rel="noopener">
+          14 enero 2025
+        </a>
+        <a href="https://blacks.university/wp-content/uploads/2025/05/002-1.jpg" target="_blank" rel="noopener">
+          1 febrero 2025
+        </a>
+        <a href="https://blacks.university/wp-content/uploads/2025/05/003-1.jpg" target="_blank" rel="noopener">
+          1 marzo 2025
+        </a>
+        <a href="https://blacks.university/wp-content/uploads/2025/05/004-1.jpg" target="_blank" rel="noopener">
+          1 abril 2025
+        </a>
+        <a href="https://blacks.university/wp-content/uploads/2025/05/005-1.jpg" target="_blank" rel="noopener">
+          1 mayo 2025
+        </a>
+      </div>
+    </section>
   );
 };
 

--- a/src/components/SalesTestimonials.tsx
+++ b/src/components/SalesTestimonials.tsx
@@ -2,17 +2,16 @@ import React from 'react';
 
 const SalesTestimonials = () => {
   return (
-    <div className="py-4">
-      <p className="text-center">
-        <span style={{ textDecoration: 'underline' }}>
-          <a href="https://blacks.university/wp-content/uploads/2025/04/ventas.jpg">
-            <span style={{ color: '#3366ff', textDecoration: 'underline' }}>
-              MILES DE PERSONAS GENERAN INGRESOS TODOS LOS DÍAS VENDIENDO NUESTROS PRODUCTOS DIGITALES
-            </span>
-          </a>
-        </span>
+    <section className="section-block">
+      <p className="section-block__heading">
+        MILES DE PERSONAS GENERAN INGRESOS TODOS LOS DÍAS VENDIENDO NUESTROS PRODUCTOS DIGITALES
       </p>
-    </div>
+      <p>
+        <a className="link-accent" href="https://blacks.university/wp-content/uploads/2025/04/ventas.jpg" target="_blank" rel="noopener">
+          VER CAPTURAS DE VENTAS
+        </a>
+      </p>
+    </section>
   );
 };
 

--- a/src/components/UserAccessLink.tsx
+++ b/src/components/UserAccessLink.tsx
@@ -2,22 +2,16 @@ import React from 'react';
 
 const UserAccessLink = () => {
   return (
-    <div className="py-2">
-      <p className="text-center">
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#3366ff' }}>
-            <a 
-              style={{ color: '#3366ff', textDecoration: 'underline' }} 
-              href="https://hotmart.com/es/club/blacks-mentorias/products/5332557" 
-              target="_blank" 
-              rel="noopener"
-            >
-              USUARIOS ACTIVOS CLICK AQUI PARA ACCEDER A LA PLATAFORMA
-            </a>
-          </span>
-        </span>
-      </p>
-    </div>
+    <section className="user-access-link section-block">
+      <a
+        className="user-access-link__anchor"
+        href="https://hotmart.com/es/club/blacks-mentorias/products/5332557"
+        target="_blank"
+        rel="noopener"
+      >
+        USUARIOS ACTIVOS CLICK AQUÍ PARA ACCEDER A LA PLATAFORMA
+      </a>
+    </section>
   );
 };
 

--- a/src/components/UserTransformations.tsx
+++ b/src/components/UserTransformations.tsx
@@ -1,75 +1,30 @@
 import React from 'react';
 
 const UserTransformations = () => {
+  const links = [
+    { label: '1', href: 'https://blacks.university/wp-content/uploads/2025/05/001.jpg' },
+    { label: '2', href: 'https://blacks.university/wp-content/uploads/2025/05/002.jpg' },
+    { label: '3', href: 'https://blacks.university/wp-content/uploads/2025/05/003.jpg' },
+    { label: '4', href: 'https://blacks.university/wp-content/uploads/2025/05/004.jpg' },
+    { label: '5', href: 'https://blacks.university/wp-content/uploads/2025/05/005.jpg' },
+    { label: '6', href: 'https://blacks.university/wp-content/uploads/2025/05/006.jpg' },
+    { label: '7', href: 'https://blacks.university/wp-content/uploads/2025/05/007.jpg' },
+    { label: '8', href: 'https://blacks.university/wp-content/uploads/2025/05/008.jpg' },
+    { label: '9', href: 'https://blacks.university/wp-content/uploads/2025/05/009.jpg' },
+    { label: '10', href: 'https://blacks.university/wp-content/uploads/2025/05/010.jpg' },
+  ];
+
   return (
-    <div className="py-6">
-      <p className="text-center py-2">MÁS USUARIOS COMPARTIENDO SU TRANSFORMACIÓN</p>
-      <p className="text-center py-2">
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#3366ff', textDecoration: 'underline' }}>
-            <a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/001.jpg">
-              1
-            </a>
-          </span>
-        </span>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#3366ff', textDecoration: 'underline' }}>
-            <a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/002.jpg">
-              2
-            </a>
-          </span>
-        </span>{" "}
-        –{" "}
-        <a href="https://blacks.university/wp-content/uploads/2025/05/003.jpg">
-          <span style={{ textDecoration: 'underline' }}>
-            <span style={{ color: '#3366ff', textDecoration: 'underline' }}>3</span>
-          </span>
-        </a>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#3366ff', textDecoration: 'underline' }}>
-            <a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/004.jpg">
-              4
-            </a>
-          </span>
-        </span>{" "}
-        –{" "}
-        <a href="https://blacks.university/wp-content/uploads/2025/05/005.jpg">
-          <span style={{ textDecoration: 'underline', color: '#3366ff' }}>5</span>
-        </a>{" "}
-        –{" "}
-        <a href="https://blacks.university/wp-content/uploads/2025/05/006.jpg">
-          <span style={{ textDecoration: 'underline', color: '#3366ff' }}>6</span>
-        </a>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <a href="https://blacks.university/wp-content/uploads/2025/05/007.jpg">
-            <span style={{ color: '#3366ff', textDecoration: 'underline' }}>7</span>
+    <section className="section-block">
+      <p className="section-block__heading">MÁS USUARIOS COMPARTIENDO SU TRANSFORMACIÓN</p>
+      <div className="transform-links">
+        {links.map((link) => (
+          <a key={link.href} href={link.href} target="_blank" rel="noopener">
+            {link.label}
           </a>
-        </span>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <span style={{ color: '#3366ff', textDecoration: 'underline' }}>
-            <a style={{ color: '#3366ff', textDecoration: 'underline' }} href="https://blacks.university/wp-content/uploads/2025/05/008.jpg">
-              8
-            </a>
-          </span>
-        </span>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <a href="https://blacks.university/wp-content/uploads/2025/05/009.jpg">
-            <span style={{ color: '#3366ff', textDecoration: 'underline' }}>9</span>
-          </a>
-        </span>{" "}
-        –{" "}
-        <span style={{ textDecoration: 'underline' }}>
-          <a href="https://blacks.university/wp-content/uploads/2025/05/010.jpg">
-            <span style={{ color: '#3366ff', textDecoration: 'underline' }}>10</span>
-          </a>
-        </span>
-      </p>
-    </div>
+        ))}
+      </div>
+    </section>
   );
 };
 

--- a/src/components/VideoGallery.tsx
+++ b/src/components/VideoGallery.tsx
@@ -1,31 +1,29 @@
 import React from 'react';
 
 const VideoGallery = () => {
-  // Videos reales del HTML original
   const videos = [
-    "https://videopress.com/embed/kIzOH5WH?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0",
-    "https://videopress.com/embed/y63TnMhj?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0",
-    "https://videopress.com/embed/KFpLOCfe?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0",
-    "https://videopress.com/embed/fUlqg3YU?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0",
-    "https://videopress.com/embed/iOWJ1DEp?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0",
-    "https://videopress.com/embed/JYSEoPou?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0"
+    'https://videopress.com/embed/kIzOH5WH?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0',
+    'https://videopress.com/embed/y63TnMhj?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0',
+    'https://videopress.com/embed/KFpLOCfe?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0',
+    'https://videopress.com/embed/fUlqg3YU?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0',
+    'https://videopress.com/embed/iOWJ1DEp?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0',
+    'https://videopress.com/embed/JYSEoPou?at&controls=1&autoPlay=0&muted=0&loop=0&playsinline=0',
   ];
-  
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-3 gap-4 py-6">
-      {videos.map((videoSrc, index) => (
-        <div key={index} className="elementor-wrapper elementor-open-inline">
-          <iframe 
-            className="elementor-video-iframe" 
-            allowFullScreen 
-            allow="clipboard-write" 
-            title={`Reproductor de vídeo videopress ${index + 1}`} 
+    <section className="section-block section-block--panel">
+      <div className="video-grid">
+        {videos.map((videoSrc, index) => (
+          <iframe
+            key={videoSrc}
+            allowFullScreen
+            allow="clipboard-write"
+            title={`Reproductor de vídeo videopress ${index + 1}`}
             src={videoSrc}
-            style={{ width: '100%', height: '200px' }}
           ></iframe>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- restyle the global theme, CTA strip, and section scaffolding to mirror the reference landing aesthetic
- reorder the homepage content and insert recurring CTA banners so the scroll matches the provided screenshots
- refresh testimonial, mentor, benefit, and FAQ components with the reference formatting and imagery

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc505cba24832d9c83176167a7ca2d